### PR TITLE
feat: Add 'new idea' command instruction

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,3 +8,4 @@
 - For all commits where I provide code, I will add `AI-assisted-by: Gemini` trailer to the commit message.
 - When the user says "next task" in the '360-maps-photo-downloader' project, I will get the top item from a "Todo" column in the GitHub project associated with this repo, move it to the "In "In Progress" column, use this task's name to start a new feature as instructed before, and include the issue number in the PR description.
 - When the user says "new task" followed by a title, I will create a new issue in the '360-maps-photo-downloader' GitHub project with that title (capitalized), add it to the "Todo" column of the project, and set its status to "Todo".
+- When the user says "new idea" followed by a title, I will create a new issue in the '360-maps-photo-downloader' GitHub project with that title (capitalized) and add it to the project without setting a status.


### PR DESCRIPTION
This PR adds a new instruction to GEMINI.md to create a new issue for ideas.

Assisted by AI using <a href=https://ai.google.dev/docs><img src=https://upload.wikimedia.org/wikipedia/commons/1/1d/Google_Gemini_icon_2025.svg width=12 height=12 alt=Gemini></a> <a href=https://ai.google.dev/docs>Gemini</a>