### PR TITLE
Only Show Clear Button When Search Is Not Empty And Move Clear Button Inside Search Field

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -484,6 +484,7 @@
 
       function clearSearch() {
         document.getElementById('search-input').value = '';
+        toggleClearButton();
         searchPhotos();
       }
 


### PR DESCRIPTION
Fixes #38

Assisted by AI using <a href=https://ai.google.dev/docs><img src=https://upload.wikimedia.org/wikipedia/commons/1/1d/Google_Gemini_icon_2025.svg width=12 height=12 alt=Gemini></a> <a href=https://ai.google.dev/docs>Gemini</a>